### PR TITLE
Fix Blizzard procSpell consumes Clearcasting

### DIFF
--- a/src/game/Spells/UnitAuraProcHandler.cpp
+++ b/src/game/Spells/UnitAuraProcHandler.cpp
@@ -550,6 +550,12 @@ void Unit::ProcDamageAndSpellFor(ProcSystemArguments& argData, bool isVictim)
             }
 
             anyAuraProc = true;
+            if (execData.procSpell && execData.spell)  // Fix Blizzard procSpell consumes Clearcasting here.
+            {
+                if (execData.procSpell->manaCost == 0 && execData.spell->m_IsTriggeredSpell && 
+                    (auraModifier->m_auraname == SPELL_AURA_ADD_FLAT_MODIFIER || auraModifier->m_auraname == SPELL_AURA_ADD_PCT_MODIFIER))
+                    useCharges = false;
+            }
         }
 
         // Remove charge (aura can be removed by triggers)


### PR DESCRIPTION
Maybe broken something else, but for currently idk.

## 🍰 Pullrequest
In the lastest cmangos-tbc core the [Blizzard](https://classic.wowhead.com/spell=10) spell triggered Blizzard(spellId:42208) spell(AuraPeriodTrigger)
and the Blizzard(spellId:42208) consumed Clearcasting(spellId:12536), which is wrong behavior.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
1.login to a mage character and level to 20.
2.learn talent "Arcane Concentration".
3.leanr spell 10.
4.cast Blizzard on mobs until triggered Clearcasting aura.
5.monitoring the combat log and you will find that the bug has been solved. 

### Todo / Checklist

- [X] As I said in comment: Maybe breaking something else, but I don't know now.
